### PR TITLE
HUMAnN2 requires diamond<0.9.0

### DIFF
--- a/yampdocker/Dockerfile
+++ b/yampdocker/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get install -q -y wget curl unzip gzip openjdk-7-jdk bc python perl samt
 
 #Updateds anaconda and uses it to install software used by YAMP
 RUN conda update conda -y
-RUN conda install -c bioconda  metaphlan2=2.6.0 qiime=1.9.1 humann2=0.9.9
+RUN conda install -c bioconda  metaphlan2=2.6.0 qiime=1.9.1 humann2=0.9.9 diamond=0.8.36
 
 #Install the last two software, namely FastQC and BBmap
 RUN wget -q -O fastqc.zip http://www.bioinformatics.babraham.ac.uk/projects/fastqc/fastqc_v0.11.5.zip && \


### PR DESCRIPTION
See requirements section at http://huttenhower.sph.harvard.edu/humann2

With diamond >=0.9.0, I get `Error: Database was built with a different version of diamond as is incompatible.`

The pre-built docker image is fine, since the bioconda package for diamond 0.9.10 was released after that docker image was built, so it has diamond 0.8.36 anyway.