### PR TITLE
Upgrade config using process selector syntax

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -125,7 +125,7 @@ process
 	queue = 'metagenome'
 	
 	
-	$qualityAssessment
+	withName: qualityAssessment
 	{
 		time =  '15m'
 		cpus = 4
@@ -133,7 +133,7 @@ process
 		jobName = "qualityAssessment"	  
 	}
 	
-	$dedup
+	withName: dedup
 	{
 		time =  '1h'
 		cpus = 4
@@ -141,7 +141,7 @@ process
 		jobName = "dedup"	  
 	}	
 	
-	$trim 
+	withName: trim 
 	{
 		time =  '1h'
 		cpus = 4
@@ -149,7 +149,7 @@ process
 		jobName = "trim"	  
 	}	
 	
-	$decontaminate 
+	withName: decontaminate 
 	{
 		time =  '3h'
 		cpus = 4
@@ -157,7 +157,7 @@ process
 		jobName = "decontaminate"	  
 	}
 	
-	$profileTaxa 
+	withName: profileTaxa 
 	{
 		time =  '2h'
 		cpus = 4
@@ -165,7 +165,7 @@ process
 		jobName = "profileTaxa"	  
 	}
 	
-	$alphaDiversity
+	withName: alphaDiversity
 	{
 		time =  '30m'
 		cpus = 1
@@ -173,7 +173,7 @@ process
 		jobName = "alphaDiversity"	  
 	}
 	
-	$profileFunction 
+	withName: profileFunction 
 	{
 		time =  '24h'
 		cpus = 4
@@ -181,7 +181,7 @@ process
 		jobName = "profileFunction"	  
 	}	
 	
-	$logQC
+	withName: logQC
 	{
 		time =  '15m'
 		cpus = 1
@@ -189,7 +189,7 @@ process
 		jobName = "logQC"	  
 	}
 	
-	$saveQCtmpfile
+	withName: saveQCtmpfile
 	{
 		time =  '1h'
 		cpus = 1
@@ -197,7 +197,7 @@ process
 		jobName = "saveQCtmpfile"	  
 	}	
 	
-	$logCC
+	withName: logCC
 	{
 		time =  '15m'
 		cpus = 1
@@ -205,7 +205,7 @@ process
 		jobName = "logCC"	  
 	}	
 	
-	$saveCCtmpfile
+	withName: saveCCtmpfile
 	{
 		time =  '15m'
 		cpus = 1


### PR DESCRIPTION
The $processName config syntax has been deprecated 
and replace with process selector syntax since version 
0.29.x

The $ syntax does not work anymore since version 0.31.0